### PR TITLE
Import Statistics for mean/var usage

### DIFF
--- a/src/analysis/metrics.jl
+++ b/src/analysis/metrics.jl
@@ -1,5 +1,6 @@
 module Analysis
 
+using Statistics
 using ..Core: Agent, ModelParams
 
 function estimate_Vstar(agents::Vector{Agent})

--- a/src/simulation/engine.jl
+++ b/src/simulation/engine.jl
@@ -1,3 +1,4 @@
+using Statistics
 using DifferentialEquations
 using ..Core: ModelParams, Agent, initialize_agents, ou_drift!, ou_diffusion!
 import ..Simulation: reset_condition, reset_affect!

--- a/src/visualization/plots.jl
+++ b/src/visualization/plots.jl
@@ -1,5 +1,6 @@
 module Visualization
 
+using Statistics
 using Plots
 using ..Core: ModelParams
 using ..Simulation: simulate!, initialize_agents


### PR DESCRIPTION
## Summary
- import Statistics in simulation engine for mean field computation
- import Statistics in analysis metrics for variance calculations
- import Statistics in visualization plots for mean equilibrium values

## Testing
- `julia --project tests/test_core.jl` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b43660bc8320ad372c374d4f40d4