### PR TITLE
Fix reset callback condition to return boolean

### DIFF
--- a/src/simulation/callbacks.jl
+++ b/src/simulation/callbacks.jl
@@ -1,11 +1,8 @@
 function reset_condition(u, t, integrator)
-    u[1] - u[2]
+    Θ, ϖ, dt = integrator.p.Θ, integrator.p.ϖ, integrator.dt
+    return abs(u[1] - u[2]) >= Θ && rand() < ϖ * dt
 end
 
 function reset_affect!(integrator)
-    Θ, ϖ = integrator.p.Θ, integrator.p.ϖ
-    u = integrator.u[1] - integrator.u[2]
-    if abs(u) >= Θ && rand() < ϖ * integrator.dt
-        integrator.u[1] = integrator.u[2]
-    end
+    integrator.u[1] = integrator.u[2]
 end


### PR DESCRIPTION
## Summary
- Correct reset_condition to return boolean probability check
- Simplify reset_affect! to only perform state reset

## Testing
- ⚠️ `julia --project -e 'include("src/core/Core.jl"); include("src/simulation/Simulation.jl"); params=Core.ModelParams(N=2,T=0.1,dt=0.01); agents=Core.initialize_agents(params); Simulation.simulate!(agents, params); println("simulation done")'` *(command not found)*
- ⚠️ `apt-get update` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b59e514083209ef1575f0c92f599