### PR TITLE
Add stability and drift visualization to phase portrait

### DIFF
--- a/src/visualization/plots.jl
+++ b/src/visualization/plots.jl
@@ -33,12 +33,37 @@ function bifurcation_plot(params::ModelParams; κ_range=0.0:0.01:2.0)
 end
 
 function phase_portrait(agents, params::ModelParams)
-    scatter([agent.r for agent in agents], [agent.x for agent in agents],
+    G = mean(agent.x - agent.r for agent in agents)
+
+    r_vals = range(-3, 3, length=20)
+    x_vals = range(-3, 3, length=20)
+    r_grid = repeat(collect(r_vals)', length(x_vals), 1)
+    x_grid = repeat(collect(x_vals), 1, length(r_vals))
+
+    dx = -params.λ .* x_grid .+ params.κ * G
+    dr = zeros(size(dx))
+
+    stable = abs.(x_grid .- r_grid) .<= params.Θ
+    stable_int = Int.(stable)
+
+    heatmap(r_vals, x_vals, stable_int;
+            c=[:red, :green],
+            alpha=0.3,
             xlabel="Anchor (r)",
             ylabel="Belief (x)",
             title="Phase Portrait (κ = $(params.κ))",
-            label="Agents",
-            alpha=0.5)
+            legend=false)
+    quiver!(r_grid, x_grid, dr, dx; color=:black, legend=false)
+
+    agent_r = [agent.r for agent in agents]
+    agent_x = [agent.x for agent in agents]
+    agent_stable = abs.(agent_x .- agent_r) .<= params.Θ
+    agent_colors = [s ? :green : :red for s in agent_stable]
+
+    scatter!(agent_r, agent_x;
+             color=agent_colors,
+             label="Agents",
+             alpha=0.8)
     plot!([-3, 3], [-3, 3], linestyle=:dash, label="x = r")
 end
 


### PR DESCRIPTION
## Summary
- compute mean-field G and grid-based deterministic drift
- shade stable vs unstable regions and overlay drift quivers
- color agents by individual stability when plotting

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c5a2c9ac8320bad19c27bb5cb57e