### PR TITLE
Refine bifurcation diagram with stability classification

### DIFF
--- a/src/main.jl
+++ b/src/main.jl
@@ -12,7 +12,7 @@ function main()
     results_dir = normpath(joinpath(@__DIR__, "..", "results"))
     mkpath(results_dir)
 
-    bif_plot = bifurcation_plot(params, κ_range=0.0:0.01:1.0)
+    bif_plot = bifurcation_plot(params)
     phase_plot = phase_portrait(agents, params)
     mean_plot = plot_mean_field(times, G_history, params)
 

--- a/src/visualization/plots.jl
+++ b/src/visualization/plots.jl
@@ -5,8 +5,42 @@ using Plots
 using ..ModelCore: ModelParams
 using ..Simulation: simulate!, initialize_agents
 
+"""
+    moving_average(data, window)
+
+Simple moving average used to smooth the mean orbit line in the bifurcation
+diagram. Points containing `NaN` are skipped when computing the local mean.
+"""
+function moving_average(data::AbstractVector{<:Real}, window::Int)
+    n = length(data)
+    smoothed = Vector{Float64}(undef, n)
+    for i in 1:n
+        lo = max(1, i - window ÷ 2)
+        hi = min(n, i + window ÷ 2)
+        vals = data[lo:hi]
+        vals = filter(!isnan, vals)
+        smoothed[i] = isempty(vals) ? NaN : mean(vals)
+    end
+    return smoothed
+end
+
+"""
+    bifurcation_plot(params; κ_range)
+
+Generate a bifurcation diagram by sweeping over `κ_range`. For each `κ`, the
+system is simulated, an initial transient (first 20% of steps) is discarded and
+the remaining orbit values of the mean-field term `G` are collected. Points are
+classified as stable when `abs(G) ≤ params.Θ` and unstable otherwise. Stable and
+unstable orbits are plotted in different colours with low opacity. A smoothed
+line through the mean of the stable orbits is overlaid for reference.
+"""
 function bifurcation_plot(params::ModelParams; κ_range=0.0:0.01:2.0)
-    bifurcation_data = Float64[]
+    stable_κ = Float64[]
+    stable_G = Float64[]
+    unstable_κ = Float64[]
+    unstable_G = Float64[]
+    stable_map = Dict{Float64, Vector{Float64}}()
+
     for κ in κ_range
         step_params = ModelParams(
             λ = params.λ,
@@ -21,15 +55,37 @@ function bifurcation_plot(params::ModelParams; κ_range=0.0:0.01:2.0)
         )
         agents = initialize_agents(step_params)
         times, G_history, _ = simulate!(agents, step_params)
-        eq_G = mean(abs.(G_history[end÷10:end]))
-        push!(bifurcation_data, eq_G)
+
+        transient_idx = floor(Int, 0.2 * length(G_history)) + 1
+        G_vals = G_history[transient_idx:end]
+
+        for G in G_vals
+            if abs(G) <= params.Θ
+                push!(stable_κ, κ)
+                push!(stable_G, G)
+                push!(get!(stable_map, κ, Float64[]), G)
+            else
+                push!(unstable_κ, κ)
+                push!(unstable_G, G)
+            end
+        end
     end
-    plot(κ_range, bifurcation_data,
-        xlabel="Peer Coupling Strength (κ)",
-        ylabel="Equilibrium Polarization (|G|)",
-        title="Bifurcation Diagram",
-        label="Polarization",
-        linewidth=2)
+
+    plt = scatter(stable_κ, stable_G,
+                  xlabel="Peer Coupling Strength (κ)",
+                  ylabel="Mean-Field Term (G)",
+                  title="Bifurcation Diagram",
+                  color=:blue, alpha=0.3, markersize=2, label="Stable")
+    scatter!(plt, unstable_κ, unstable_G,
+             color=:red, alpha=0.3, markersize=2, label="Unstable")
+
+    stable_means = [haskey(stable_map, κ) ? mean(stable_map[κ]) : NaN for κ in κ_range]
+    smoothed = moving_average(stable_means, 5)
+    valid = .!isnan(smoothed)
+    plot!(plt, collect(κ_range)[valid], smoothed[valid],
+          color=:blue, linewidth=2, label="Stable mean")
+
+    return plt
 end
 
 function phase_portrait(agents, params::ModelParams)


### PR DESCRIPTION
## Summary
- Expand `bifurcation_plot` to collect post-transient orbits across κ values and classify stability based on threshold Θ.
- Scatter stable and unstable points with low alpha and overlay a smoothed mean line for stable regions.
- Update main script to generate and save the enhanced bifurcation diagram.

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'` *(fails: `bash: command not found: julia`)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c6e5464c83209d97e8c8ac69d46b