### PR TITLE
Rename phase portrait outputs to avoid filename collisions

### DIFF
--- a/scripts/generate_plots.jl
+++ b/scripts/generate_plots.jl
@@ -188,7 +188,7 @@ function plot_phase_portrait(params, κ_to_plot; results_dir=".")
 
     quiver!(p, x_range, y_range, quiver=(u_field, v_field))
 
-    savefig(p, joinpath(results_dir, "phase_portrait.png"))
+    savefig(p, joinpath(results_dir, "ou_phase_portrait.png"))
     return p
 end
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -18,7 +18,7 @@ function main()
     mean_plot = plot_mean_field(times, G_history, params)
 
     savefig(bif_plot, joinpath(results_dir, "bifurcation_plot.png"))
-    savefig(phase_plot, joinpath(results_dir, "phase_portrait.png"))
+    savefig(phase_plot, joinpath(results_dir, "model_phase_portrait.png"))
     savefig(mean_plot, joinpath(results_dir, "mean_field.png"))
 
     generate_ou_with_resets_plots(results_dir)


### PR DESCRIPTION
## Summary
- Save OU-with-resets phase portrait as `ou_phase_portrait.png` to avoid clashing with other outputs
- Rename main phase portrait output to `model_phase_portrait.png`

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f33ced348320aecabee6d80b8b89