### PR TITLE
Replace deprecated twinx axis option in plot generation script

### DIFF
--- a/scripts/generate_plots.jl
+++ b/scripts/generate_plots.jl
@@ -206,7 +206,7 @@ function plot_time_series(λ, σ, Θ, N, T, dt; results_dir=".")
 
     p1 = plot(times_c, beliefs_c, label="", color=:lightgray, lw=0.5, title="Consensus (κ < κ*)")
     plot!(p1, times_c, means_c, label="Mean", lw=2, color=:blue)
-    plot!(p1, times_c, variances_c, label="Variance", lw=2, color=:red, yaxis=:twinx)
+    plot!(p1, times_c, variances_c, label="Variance", lw=2, color=:red, yaxis=:right)
 
     # Case 2: Polarization (κ > κ*)
     κ_polarization = 1.2 * κ_critical
@@ -215,7 +215,7 @@ function plot_time_series(λ, σ, Θ, N, T, dt; results_dir=".")
 
     p2 = plot(times_p, beliefs_p, label="", color=:lightgray, lw=0.5, title="Polarization (κ > κ*)")
     plot!(p2, times_p, means_p, label="Mean", lw=2, color=:blue)
-    plot!(p2, times_p, variances_p, label="Variance", lw=2, color=:red, yaxis=:twinx)
+    plot!(p2, times_p, variances_p, label="Variance", lw=2, color=:red, yaxis=:right)
 
     combined_plot = plot(p1, p2, layout=(1, 2), size=(1200, 600))
     savefig(combined_plot, joinpath(results_dir, "time_series_plots.png"))


### PR DESCRIPTION
## Summary
- use Plots.jl's right-side axis in time series plots instead of deprecated `:twinx`

## Testing
- `julia -q --project=. -e 'include("scripts/generate_plots.jl"); generate_ou_with_resets_plots("results")'` *(fails: command not found: julia)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5fbc6367883209f3af30bb5adb85f