### PR TITLE
Use twinx for variance plots in time series

### DIFF
--- a/scripts/generate_plots.jl
+++ b/scripts/generate_plots.jl
@@ -224,7 +224,8 @@ function plot_time_series(λ, σ, Θ, N, T, dt; results_dir=".")
 
     p1 = plot(times_c, beliefs_c, label="", color=:lightgray, lw=0.5, title="Consensus (κ < κ*)")
     plot!(p1, times_c, means_c, label="Mean", lw=2, color=:blue)
-    plot!(p1, times_c, variances_c, label="Variance", lw=2, color=:red, yaxis=:right)
+    ax_c = twinx()
+    plot!(ax_c, times_c, variances_c; label="Variance", color=:red, lw=2)
 
     # Case 2: Polarization (κ > κ*)
     κ_polarization = 1.2 * κ_critical
@@ -233,7 +234,8 @@ function plot_time_series(λ, σ, Θ, N, T, dt; results_dir=".")
 
     p2 = plot(times_p, beliefs_p, label="", color=:lightgray, lw=0.5, title="Polarization (κ > κ*)")
     plot!(p2, times_p, means_p, label="Mean", lw=2, color=:blue)
-    plot!(p2, times_p, variances_p, label="Variance", lw=2, color=:red, yaxis=:right)
+    ax_p = twinx()
+    plot!(ax_p, times_p, variances_p; label="Variance", color=:red, lw=2)
 
     combined_plot = plot(p1, p2, layout=(1, 2), size=(1200, 600))
     savefig(combined_plot, joinpath(results_dir, "time_series_plots.png"))


### PR DESCRIPTION
## Summary
- Use `twinx()` to create secondary y-axes in time series plots
- Plot variance on the secondary axis for both consensus and polarization cases

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden, unable to install Julia)*
- `julia scripts/generate_plots.jl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c602b80c5483208668ce36a9368619