### PR TITLE
Use grid matrices for phase portrait

### DIFF
--- a/scripts/generate_plots.jl
+++ b/scripts/generate_plots.jl
@@ -173,41 +173,29 @@ function plot_phase_portrait(params, κ_to_plot; results_dir=".")
     x_range = range(-2, 2, length=20)
     y_range = range(0, 5, length=20)
     nx, ny = length(x_range), length(y_range)
-    u_field = zeros(nx, ny)
-    v_field = zeros(nx, ny)
-    stability_metric = zeros(nx, ny)
-    arrow_colors = Array{Symbol}(undef, nx, ny)
+    x_grid = [x for x in x_range, y in y_range]
+    y_grid = [y for x in x_range, y in y_range]
 
     κ_critical = (params[:σ]^2) / (2 * V_star(params[:λ], params[:σ], 0.0, 0.0))
 
-    for i in 1:nx
-        x = x_range[i]
-        for j in 1:ny
-            y = y_range[j]
-            # Simplified vector field for illustration
-            u = -x
-            if κ_to_plot < κ_critical
-                v = -y
-                dv_dy = -1
-            else
-                v = -y + y^2
-                dv_dy = -1 + 2y
-            end
-            u_field[i, j] = u
-            v_field[i, j] = v
-            J = [-1 0; 0 dv_dy]  # Jacobian at (x, y)
-            dom_eig = maximum(real.(eigvals(J)))
-            stability_metric[i, j] = dom_eig
-            arrow_colors[i, j] = dom_eig < 0 ? :blue : :red
-        end
+    u_field = .-x_grid
+    if κ_to_plot < κ_critical
+        v_field = .-y_grid
+        dv_dy_field = fill(-1.0, size(y_grid))
+    else
+        v_field = -y_grid .+ y_grid.^2
+        dv_dy_field = -1 .+ 2 .* y_grid
     end
+
+    stability_metric = max.(-1, dv_dy_field)
+    arrow_colors = map(x -> x < 0 ? :blue : :red, stability_metric)
 
     # Optional heatmap overlay of stability metric
     heatmap!(p, x_range, y_range, stability_metric; alpha=0.3,
              c=cgrad(:RdBu), colorbar=false)
 
     # Quiver plot with arrows colored by stability
-    quiver!(p, x_range, y_range, quiver=(u_field, v_field),
+    quiver!(p, x_grid, y_grid, quiver=(u_field, v_field),
             c=arrow_colors, colorbar=false, label="")
     scatter!([NaN], [NaN], m=:circle, color=:blue, label="Stable (Re<0)")
     scatter!([NaN], [NaN], m=:circle, color=:red, label="Unstable (Re>0)")


### PR DESCRIPTION
## Summary
- generate x/y grid matrices and broadcast to compute phase-portrait vectors
- pass grid-aligned u/v matrices to `quiver!` to avoid color-index warnings

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c60a8839888320b44e66992b7a91cc